### PR TITLE
Don't crash if SDL AudioDevice fails to open

### DIFF
--- a/cpu.rs
+++ b/cpu.rs
@@ -25,8 +25,8 @@ static BREAK_FLAG:    uint8_t = 1 << 4;
 static OVERFLOW_FLAG: uint8_t = 1 << 6;
 static NEGATIVE_FLAG: uint8_t = 1 << 7;
 
-static NMI_VECTOR:   uint16_t = 0xfffa; 
-static RESET_VECTOR: uint16_t = 0xfffc; 
+static NMI_VECTOR:   uint16_t = 0xfffa;
+static RESET_VECTOR: uint16_t = 0xfffc;
 static BRK_VECTOR:   uint16_t = 0xfffe;
 
 /// The number of cycles that each machine operation takes. Indexed by opcode number.
@@ -313,7 +313,7 @@ macro_rules! decode_op {
             // No operation
             0xea => $this.nop(),
 
-            _ => fail!("unimplemented or illegal instruction")
+            _ => fail!("unimplemented or illegal instruction: {}", $op)
         }
     }
 }
@@ -819,4 +819,3 @@ impl<M:Mem> Cpu<M> {
     /// The constructor.
     pub fn new(mem: M) -> Cpu<M> { Cpu { cy: 0, regs: Regs::new(), mem: mem } }
 }
-

--- a/main.rs
+++ b/main.rs
@@ -157,4 +157,3 @@ pub fn start(argc: int32_t, argv: *const *const uint8_t) {
 
     audio::close();
 }
-

--- a/nes.rs
+++ b/nes.rs
@@ -37,4 +37,3 @@ pub mod speex;
 pub extern "C" fn main(argc: int32_t, argv: *const *const uint8_t) -> int32_t {
     native::start(argc as int, argv, proc() main::start(argc, argv)) as int32_t
 }
-

--- a/ppu.rs
+++ b/ppu.rs
@@ -823,7 +823,7 @@ impl Ppu {
 
             if self.scanline == (VBLANK_SCANLINE as uint16_t) {
                 self.start_vblank(&mut result);
-            } else if self.scanline == (LAST_SCANLINE as uint16_t) { 
+            } else if self.scanline == (LAST_SCANLINE as uint16_t) {
                 result.new_frame = true;
                 self.scanline = 0;
                 self.regs.status.set_in_vblank(false);
@@ -837,4 +837,3 @@ impl Ppu {
         return result;
     }
 }
-

--- a/rom.rs
+++ b/rom.rs
@@ -97,4 +97,3 @@ impl INesHeader {
                  })).to_string()
     }
 }
-

--- a/util.rs
+++ b/util.rs
@@ -175,4 +175,3 @@ pub fn current_time_millis() -> uint64_t {
         (tv.tv_sec as uint64_t) * 1000 + (tv.tv_usec as uint64_t) / 1000
     }
 }
-


### PR DESCRIPTION
So I kept getting an error in AudioDevice::open() in audio.rs - which was crashing the program since it wasn't being error checked. 
I'm still trying to figure out why the error is happening in the first place - SDL2 is calling an IXAudio2 API call which is returning an "invalid access to memory location" error code.
But anyways, here's my fix
