### PR TITLE
Update for rust-0.13-nightly and latest rust-sdl2.

### DIFF
--- a/apu.rs
+++ b/apu.rs
@@ -12,7 +12,6 @@ use util::{Save, Xorshift};
 
 use libc::{int16_t, int32_t, uint8_t, uint16_t, uint32_t, uint64_t};
 use std::io::File;
-use std::owned::Box;
 
 const CYCLES_PER_EVEN_TICK: uint64_t = 7438;
 const CYCLES_PER_ODD_TICK: uint64_t = 7439;
@@ -72,7 +71,7 @@ impl ApuLength {
                 self.id = val >> 3;
                 self.remaining = LENGTH_COUNTERS[self.id as uint];
             }
-            _ => fail!("can't happen"),
+            _ => panic!("can't happen"),
         }
     }
 
@@ -163,7 +162,7 @@ impl ApuTimer {
             0 | 1 => {}
             2 => self.value = (self.value & 0xff00) | (val as uint16_t),
             3 => self.value = (self.value & 0x00ff) | ((val as uint16_t & 0x7) << 8),
-            _ => fail!("can't happen"),
+            _ => panic!("can't happen"),
         }
     }
 
@@ -447,7 +446,7 @@ impl Apu {
                 pulse.sweep_cycle = 0;
             }
             2 | 3 => {}
-            _ => fail!("can't happen"),
+            _ => panic!("can't happen"),
         }
     }
 

--- a/cpu.rs
+++ b/cpu.rs
@@ -91,7 +91,7 @@ impl<M> AddressingMode<M> for ImmediateAddressingMode where M: Mem {
     fn load(&self, cpu: &mut Cpu<M>) -> uint8_t { cpu.loadb_bump_pc() }
     fn store(&self, _: &mut Cpu<M>, _: uint8_t) {
         // Not particularly type-safe, but probably not worth using trait inheritance for this.
-        fail!("can't store to immediate")
+        panic!("can't store to immediate")
     }
 }
 
@@ -313,7 +313,7 @@ macro_rules! decode_op {
             // No operation
             0xea => $this.nop(),
 
-            _ => fail!("unimplemented or illegal instruction: {}", $op)
+            _ => panic!("unimplemented or illegal instruction: {}", $op)
         }
     }
 }

--- a/gfx.rs
+++ b/gfx.rs
@@ -12,7 +12,6 @@ use sdl2::video::{PosCentered, Window, INPUT_FOCUS};
 use sdl2;
 
 use libc::{int32_t, uint8_t};
-use std::owned::Box;
 
 const SCREEN_WIDTH: uint = 256;
 const SCREEN_HEIGHT: uint = 240;
@@ -235,7 +234,7 @@ impl StatusLineText {
             return;
         }
         let y = match self.animation {
-            Idle => fail!(),
+            Idle => panic!(),
             SlidingOut(y) => y as int,
             Pausing(_) => STATUS_LINE_Y as int,
         };
@@ -282,7 +281,7 @@ impl Scale {
 }
 
 pub struct Gfx {
-    pub renderer: Box<Renderer<Window>>,
+    pub renderer: Box<Renderer>,
     pub texture: Box<Texture>,
     pub scale: Scale,
     pub status_line: StatusLine,

--- a/input.rs
+++ b/input.rs
@@ -45,7 +45,7 @@ impl StrobeState {
             STROBE_STATE_DOWN   => state.down,
             STROBE_STATE_LEFT   => state.left,
             STROBE_STATE_RIGHT  => state.right,
-            _                   => fail!("shouldn't happen")
+            _                   => panic!("shouldn't happen")
         }
     }
 

--- a/main.rs
+++ b/main.rs
@@ -22,7 +22,6 @@ use libc::{int32_t, uint8_t, uint64_t};
 use std::cell::RefCell;
 use std::io::File;
 use std::mem;
-use std::owned::Box;
 use std::rc::Rc;
 use std::string;
 

--- a/mapper.rs
+++ b/mapper.rs
@@ -8,7 +8,6 @@ use rom::Rom;
 use util;
 
 use libc::{uint8_t, uint16_t};
-use std::owned::Box;
 
 #[deriving(PartialEq, Eq)]
 pub enum MapperResult {
@@ -33,7 +32,7 @@ pub fn create_mapper(rom: Box<Rom>) -> Box<Mapper+Send> {
         },
         1 => box SxRom::new(rom) as Box<Mapper+Send>,
         4 => box TxRom::new(rom) as Box<Mapper+Send>,
-        _ => fail!("unsupported mapper")
+        _ => panic!("unsupported mapper")
     }
 }
 
@@ -97,7 +96,7 @@ impl SxCtrl {
             0 | 1 => Switch32K,
             2 => FixFirstBank,
             3 => FixLastBank,
-            _ => fail!("can't happen")
+            _ => panic!("can't happen")
         }
     }
 }
@@ -316,7 +315,7 @@ impl Mapper for TxRom {
                     0 ... 1 => self.chr_banks_2k[bank_update_select] = val,
                     2 ... 5 => self.chr_banks_1k[bank_update_select - 2] = val,
                     6 ... 7 => self.prg_banks[bank_update_select - 6] = val,
-                    _ => fail!()
+                    _ => panic!()
                 }
             }
         } else if addr < 0xc000 {

--- a/mem.rs
+++ b/mem.rs
@@ -13,7 +13,6 @@ use util::Save;
 use libc::{uint8_t, uint16_t};
 use std::cell::RefCell;
 use std::io::File;
-use std::owned::Box;
 use std::rc::Rc;
 
 //

--- a/ppu.rs
+++ b/ppu.rs
@@ -11,7 +11,6 @@ use util::{Save, debug_assert};
 use libc::{uint8_t, uint16_t, uint64_t};
 use std::cell::RefCell;
 use std::io::File;
-use std::owned::Box;
 use std::rc::Rc;
 
 //
@@ -222,7 +221,7 @@ impl Mem for Vram {
         } else if addr < 0x4000 {   // Palette area
             self.palette[addr as uint & 0x1f]
         } else {
-            fail!("invalid VRAM read")
+            panic!("invalid VRAM read")
         }
     }
     fn storeb(&mut self, addr: uint16_t, val: uint8_t) {
@@ -367,11 +366,11 @@ impl Mem for Ppu {
             1 => *self.regs.mask,
             2 => self.read_ppustatus(),
             3 => 0, // OAMADDR is read-only
-            4 => fail!("OAM read unimplemented"),
+            4 => panic!("OAM read unimplemented"),
             5 => 0, // PPUSCROLL is read-only
             6 => 0, // PPUADDR is read-only
             7 => self.read_ppudata(),
-            _ => fail!("can't happen")
+            _ => panic!("can't happen")
         }
     }
 
@@ -387,7 +386,7 @@ impl Mem for Ppu {
             5 => self.update_ppuscroll(val),
             6 => self.update_ppuaddr(val),
             7 => self.write_ppudata(val),
-            _ => fail!("can't happen")
+            _ => panic!("can't happen")
         }
     }
 }

--- a/util.rs
+++ b/util.rs
@@ -4,7 +4,7 @@
 // Author: Patrick Walton
 //
 
-#![allow(ctypes)]
+#![allow(improper_ctypes)]
 
 use libc::{c_int, c_void, time_t, uint8_t, uint16_t, uint32_t, uint64_t};
 use std::io::File;


### PR DESCRIPTION
```
* Rename fail! to panic!
* Remove occurrences of "use std::owned::Box".
* Renderer<T> is now just Renderer in rust-sdl2.
* Rename lint from "ctypes" to "improper_ctypes".
```
