### PR TITLE
Pin SDL to the correct version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [ "pcwalton@mimiga.net" ]
 name = "nes"
 
 [dependencies]
-sdl2 = "*"
+sdl2 = "0.6.0"
 time = "*"
 libc = "*"
 lazy_static = "*"


### PR DESCRIPTION
SDL2 has since released an incompatible 0.7, so pin to 0.6 for now.