### PR TITLE
Fix some arithmetic overflow errors

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -557,7 +557,7 @@ impl Apu {
                     if pulse.sweep.enabled() {
                         let delta = pulse.timer.value >> pulse.sweep.shift_count() as usize;
                         if !pulse.sweep.negate() {
-                            pulse.timer.value += delta;
+                            pulse.timer.value = (pulse.timer.value as u32 + delta as u32) as u16;
                         } else {
                             pulse.timer.value -= delta;
                         }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -545,7 +545,7 @@ impl<M: Mem> Cpu<M> {
     fn sbc<AM:AddressingMode<M>>(&mut self, am: AM) {
         let val = am.load(self);
         let a = self.regs.a;
-        let mut result = a as u32 - val as u32;
+        let mut result = a as i16 - val as i16;
         if !self.get_flag(CARRY_FLAG) {
             result -= 1;
         }
@@ -561,7 +561,7 @@ impl<M: Mem> Cpu<M> {
     // Comparisons
     fn cmp_base<AM:AddressingMode<M>>(&mut self, x: u8, am: AM) {
         let y = am.load(self);
-        let result = x as u32 - y as u32;
+        let result = x as i16 - y as i16;
         self.set_flag(CARRY_FLAG, (result & 0x100) == 0);
         let _ = self.set_zn(result as u8);
     }
@@ -636,29 +636,29 @@ impl<M: Mem> Cpu<M> {
     // Increments and decrements
     fn inc<AM:AddressingMode<M>>(&mut self, am: AM) {
         let val = am.load(self);
-        let val = self.set_zn(val + 1);
+        let val = self.set_zn((val as u16 + 1) as u8);
         am.store(self, val)
     }
     fn dec<AM:AddressingMode<M>>(&mut self, am: AM) {
         let val = am.load(self);
-        let val = self.set_zn(val - 1);
+        let val = self.set_zn((val as i16 - 1) as u8);
         am.store(self, val)
     }
     fn inx(&mut self) {
         let x = self.regs.x;
-        self.regs.x = self.set_zn(x + 1)
+        self.regs.x = self.set_zn((x as u16 + 1) as u8)
     }
     fn dex(&mut self) {
         let x = self.regs.x;
-        self.regs.x = self.set_zn(x - 1)
+        self.regs.x = self.set_zn((x as i16 - 1) as u8)
     }
     fn iny(&mut self) {
         let y = self.regs.y;
-        self.regs.y = self.set_zn(y + 1)
+        self.regs.y = self.set_zn((y as u16 + 1 as u16) as u8)
     }
     fn dey(&mut self) {
         let y = self.regs.y;
-        self.regs.y = self.set_zn(y - 1)
+        self.regs.y = self.set_zn((y as i16 - 1) as u8)
     }
 
     // Register moves

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -345,7 +345,7 @@ impl SpriteStruct {
 
     // Quick test to see whether the given point is in the bounding box of this sprite.
     fn in_bounding_box(&self, ppu: &Ppu, x: u8, y: u8) -> bool {
-        x >= self.x && x < self.x + 8 && self.on_scanline(ppu, y)
+        x >= self.x && (x as u16) < self.x as u16 + 8 && self.on_scanline(ppu, y)
     }
 }
 
@@ -530,7 +530,7 @@ impl Ppu {
 
     fn write_oamdata(&mut self, val: u8) {
         self.oam.storeb(self.regs.oam_addr as u16, val);
-        self.regs.oam_addr += 1;
+        self.regs.oam_addr = (self.regs.oam_addr as u16 + 1) as u8;
     }
 
     fn update_ppuaddr(&mut self, val: u8) {


### PR DESCRIPTION
So far I've been finding these by playing a game until it crashes. To find all of them, I'd probably need to do a thorough line-by-line audit or run a fuzzer.

I might try using afl-fuzz to catch the rest of these, sometime.
