### PR TITLE
Make the audio module less unsafe

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -7,10 +7,9 @@
 // TODO: This module is very unsafe. Adding a reader-writer audio lock to SDL would help make it
 // safe.
 
-use sdl2::audio::{AudioCallback, AudioDevice, AudioDeviceLockGuard, AudioSpecDesired};
+use sdl2::audio::{AudioCallback, AudioDevice, AudioSpecDesired};
 use sdl2::Sdl;
 use std::cmp;
-use std::mem;
 use std::slice::from_raw_parts_mut;
 use std::sync::{Condvar, Mutex};
 
@@ -20,21 +19,15 @@ use std::sync::{Condvar, Mutex};
 
 const SAMPLE_COUNT: usize = 4410 * 2;
 
-static mut G_AUDIO_DEVICE: Option<*mut AudioDevice<NesAudioCallback>> = None;
-
-static mut G_OUTPUT_BUFFER: Option<*mut OutputBuffer> = None;
-
 lazy_static! {
     pub static ref AUDIO_MUTEX: Mutex<()> = Mutex::new(());
     pub static ref AUDIO_CONDVAR: Condvar = Condvar::new();
 }
 
-pub struct OutputBuffer {
+pub struct NesAudioCallback {
     pub samples: [u8; SAMPLE_COUNT],
     pub play_offset: usize,
 }
-
-pub struct NesAudioCallback;
 
 impl AudioCallback for NesAudioCallback {
     type Channel = i16;
@@ -43,38 +36,26 @@ impl AudioCallback for NesAudioCallback {
         unsafe {
             let samples: &mut [u8] =
                 from_raw_parts_mut(&mut buf[0] as *mut i16 as *mut u8, buf.len() * 2);
-            let output_buffer: &mut OutputBuffer = mem::transmute(G_OUTPUT_BUFFER.unwrap());
-            let play_offset = output_buffer.play_offset;
-            let output_buffer_len = output_buffer.samples.len();
+            let play_offset = self.play_offset;
+            let output_buffer_len = self.samples.len();
 
             for i in 0..samples.len() {
                 if i + play_offset >= output_buffer_len {
                     break;
                 }
-                samples[i] = output_buffer.samples[i + play_offset];
+                samples[i] = self.samples[i + play_offset];
             }
 
             let _ = AUDIO_MUTEX.lock();
-            output_buffer.play_offset = cmp::min(play_offset + samples.len(), output_buffer_len);
+            self.play_offset = cmp::min(play_offset + samples.len(), output_buffer_len);
             AUDIO_CONDVAR.notify_one();
         }
     }
 }
 
-/// Audio initialization. If successful, returns a pointer to an allocated `OutputBuffer` that can
-/// be filled with raw audio data.
-pub fn open(sdl: &Sdl) -> Option<*mut OutputBuffer> {
-    let output_buffer = Box::new(OutputBuffer {
-        samples: [0; SAMPLE_COUNT],
-        play_offset: 0,
-    });
-    let output_buffer_ptr: *mut OutputBuffer = unsafe { mem::transmute(&*output_buffer) };
-
-    unsafe {
-        G_OUTPUT_BUFFER = Some(output_buffer_ptr);
-        mem::forget(output_buffer);
-    }
-
+/// Audio initialization. If successful, returns an SDL AudioDevice that can be used (by locking)
+/// to get an output buffer reference to be filled with raw audio data.
+pub fn open(sdl: &Sdl) -> Option<AudioDevice<NesAudioCallback>> {
     let spec = AudioSpecDesired {
         freq: Some(44100),
         channels: Some(1),
@@ -82,37 +63,17 @@ pub fn open(sdl: &Sdl) -> Option<*mut OutputBuffer> {
     };
 
     let audio_subsystem = sdl.audio().unwrap();
-    unsafe {
-        match audio_subsystem.open_playback(None, &spec, |_| NesAudioCallback) {
-            Ok(device) => {
-                device.resume();
-                G_AUDIO_DEVICE = Some(mem::transmute(Box::new(device)));
-                return Some(output_buffer_ptr);
-            }
-            Err(e) => {
-                println!("Error initializing AudioDevice: {}", e);
-                return None;
-            }
+    match audio_subsystem.open_playback(None, &spec, |_| NesAudioCallback {
+        samples: [0; SAMPLE_COUNT],
+        play_offset: 0,
+    }) {
+        Ok(device) => {
+            device.resume();
+            return Some(device);
+        }
+        Err(e) => {
+            println!("Error initializing AudioDevice: {}", e);
+            return None;
         }
     }
-}
-
-//
-// Audio tear-down
-//
-
-pub fn close() {
-    unsafe {
-        match G_AUDIO_DEVICE {
-            None => {}
-            Some(ptr) => {
-                let _: Box<AudioDevice<NesAudioCallback>> = mem::transmute(ptr);
-                G_AUDIO_DEVICE = None;
-            }
-        }
-    }
-}
-
-pub fn lock<'a>() -> Option<AudioDeviceLockGuard<'a, NesAudioCallback>> {
-    unsafe { G_AUDIO_DEVICE.map(|dev| (*dev).lock()) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,13 +61,13 @@ pub fn start_emulator(rom: Rom, scale: Scale) {
     println!("Loaded ROM: {}", rom.header);
 
     let (mut gfx, sdl) = Gfx::new(scale);
-    let audio_buffer = audio::open(&sdl);
+    let audio_device = audio::open(&sdl);
 
     let mapper: Box<Mapper + Send> = mapper::create_mapper(rom);
     let mapper = Rc::new(RefCell::new(mapper));
     let ppu = Ppu::new(Vram::new(mapper.clone()), Oam::new());
     let input = Input::new(sdl);
-    let apu = Apu::new(audio_buffer);
+    let apu = Apu::new(audio_device);
     let memmap = MemMap::new(ppu, input, mapper, apu);
     let mut cpu = Cpu::new(memmap);
 
@@ -109,6 +109,4 @@ pub fn start_emulator(rom: Rom, scale: Scale) {
             }
         }
     }
-
-    audio::close();
 }


### PR DESCRIPTION
This is achieved by eliminating two global variables and making the code
work nicely with ownership analysis.

This is possible because AudioDevice<NesCallback> has a lock method that
returns an object that dereferences to NesCallback we can store the
output buffer directly in NesCallback and then safely access it to
update the raw sound data.

The resulting code is easier to follow and contains fewer unsafe blocks.